### PR TITLE
Hash-bang fragment usage bugfix.

### DIFF
--- a/connectors/storage/fixture/.testdata/init.lua
+++ b/connectors/storage/fixture/.testdata/init.lua
@@ -1,5 +1,5 @@
--- SPDX-License-Identifier: BUSL-1.1
 #!/usr/bin/env tarantool
+-- SPDX-License-Identifier: BUSL-1.1
 -- Details: https:www.tarantool.io/en/doc/latest/reference/configuration/
 require "lfs"
 lfs.mkdir("./memtx")


### PR DESCRIPTION
Hash-bang fragment (shebang) can be only at the first line of the lua script.