### PR TITLE
accounts bridging support

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -88,6 +88,13 @@ func (a *auth) DeleteUser(ctx context.Context, userID string) error {
 
 	return nil
 }
+func (a *auth) UpdateEmail(ctx context.Context, userID, email string) error {
+	if usr, err := a.fb.GetUser(ctx, userID); err == nil && usr != nil {
+		return errors.Wrapf(a.fb.UpdateEmail(ctx, userID, email), "failed to update email for user:%v to %v using firebase auth", userID, email)
+	}
+
+	return nil
+}
 
 func (a *auth) GenerateTokens( //nolint:revive // We need to have these parameters.
 	now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string,

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -56,6 +56,12 @@ func (a *auth) GenerateTokens( //nolint:revive // We need to have these paramete
 	return
 }
 
+func (a *auth) GenerateMetadata(
+	now *time.Time, userID string, metadata map[string]any,
+) (string, error) {
+	return a.ice.GenerateMetadata(now, userID, metadata)
+}
+
 func (a *auth) ParseToken(token string) (*IceToken, error) {
 	res := new(IceToken)
 	err := a.ice.VerifyTokenFields(token, res)

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -103,7 +103,7 @@ func (a *auth) GenerateMetadata(
 ) (string, error) {
 	md, err := a.ice.GenerateMetadata(now, tokenID, metadata)
 
-	return md, errors.Wrapf(err, "failed to generate metadata token for token %v", tokenID)
+	return md, errors.Wrapf(err, "failed to generate metadata token for tokenID:%v", tokenID)
 }
 
 func (a *auth) ParseToken(token string) (*IceToken, error) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -74,27 +74,15 @@ func (*auth) firstRegisteredUserID(metadata map[string]any) string {
 }
 
 func (a *auth) UpdateCustomClaims(ctx context.Context, userID string, customClaims map[string]any) error {
-	if usr, err := a.fb.GetUser(ctx, userID); err == nil && usr != nil {
-		return errors.Wrapf(a.fb.UpdateCustomClaims(ctx, userID, customClaims), "failed to update custom claims for user:%v using firebase auth", userID)
-	}
-
-	return nil
+	return errors.Wrapf(a.fb.UpdateCustomClaims(ctx, userID, customClaims), "failed to update custom claims for user:%v using firebase auth", userID)
 }
 
 func (a *auth) DeleteUser(ctx context.Context, userID string) error {
-	if usr, err := a.fb.GetUser(ctx, userID); err == nil && usr != nil {
-		return errors.Wrapf(a.fb.DeleteUser(ctx, userID), "failed to delete user:%v using firebase auth", userID)
-	}
-
-	return nil
+	return errors.Wrapf(a.fb.DeleteUser(ctx, userID), "failed to delete user:%v using firebase auth", userID)
 }
 
 func (a *auth) UpdateEmail(ctx context.Context, userID, email string) error {
-	if usr, err := a.fb.GetUser(ctx, userID); err == nil && usr != nil {
-		return errors.Wrapf(a.fb.UpdateEmail(ctx, userID, email), "failed to update email for user:%v to %v using firebase auth", userID, email)
-	}
-
-	return nil
+	return errors.Wrapf(a.fb.UpdateEmail(ctx, userID, email), "failed to update email for user:%v to %v using firebase auth", userID, email)
 }
 
 func (a *auth) GenerateTokens( //nolint:revive // We need to have these parameters.

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -88,6 +88,7 @@ func (a *auth) DeleteUser(ctx context.Context, userID string) error {
 
 	return nil
 }
+
 func (a *auth) UpdateEmail(ctx context.Context, userID, email string) error {
 	if usr, err := a.fb.GetUser(ctx, userID); err == nil && usr != nil {
 		return errors.Wrapf(a.fb.UpdateEmail(ctx, userID, email), "failed to update email for user:%v to %v using firebase auth", userID, email)

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -270,6 +270,10 @@ func TestMetadata_Empty(t *testing.T) {
 	assert.Equal(t, decodedMetadata["sub"], userID)
 	assert.Equal(t, decodedMetadata["iss"], internal.MetadataIssuer)
 	assert.Equal(t, int64(decodedMetadata["iat"].(float64)), now.Unix()) //nolint:forcetypeassert // .
+
+	err = client.ModifyTokenWithMetadata(tok, "")
+	require.NoError(t, err)
+	assert.Equal(t, tok.UserID, userID)
 }
 
 func TestMetadata_RegisteredBy(t *testing.T) { //nolint:funlen // .

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -86,8 +86,6 @@ func TestUpdateCustomClaims_Success(t *testing.T) {
 	require.NoError(t, client.UpdateCustomClaims(ctx, uid, map[string]any{"a": 1, "b": map[string]any{"c": "x"}}))
 	require.NoError(t, client.UpdateCustomClaims(ctx, uid, map[string]any{"b": map[string]any{"d": "y"}}))
 	require.ErrorIs(t, client.(*auth).fb.UpdateCustomClaims(ctx, uuid.NewString(), map[string]any{"a": 1}), ErrUserNotFound) //nolint:forcetypeassert // .
-	// Ice no-op is called when user does not exist in firebase.
-	require.NoError(t, client.UpdateCustomClaims(ctx, uuid.NewString(), map[string]any{"a": 1}))
 	user, err = fixture.GetUser(ctx, uid)
 	require.NoError(t, err)
 	require.EqualValues(t, map[string]any{"a": 1.0, "b": map[string]any{"c": "x", "d": "y"}, "role": "app"}, user.CustomClaims)
@@ -186,7 +184,7 @@ func TestUpdateCustomClaims_Ice(t *testing.T) {
 			"role": "author",
 		}
 	)
-	require.NoError(t, client.UpdateCustomClaims(ctx, userID, claims))
+	require.Error(t, client.UpdateCustomClaims(ctx, userID, claims), ErrUserNotFound)
 }
 
 func TestDeleteUser_Ice(t *testing.T) {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -157,9 +157,8 @@ func TestGenerateIceTokens_Valid(t *testing.T) {
 		email    = "bogus@bogus.com"
 		deviceID = "00000000-0000-0000-0000-000000000001"
 		role     = "author"
-		claims   = map[string]any{"role": role, "reallyCustomClaim": "claimData"}
 	)
-	refreshToken, accessToken, err := client.GenerateTokens(now, userID, deviceID, email, hashCode, seq, claims)
+	refreshToken, accessToken, err := client.GenerateTokens(now, userID, deviceID, email, hashCode, seq, role)
 	require.NoError(t, err)
 	assert.NotEmpty(t, refreshToken)
 	assert.NotEmpty(t, accessToken)
@@ -173,7 +172,6 @@ func TestGenerateIceTokens_Valid(t *testing.T) {
 	assert.Equal(t, seq, verifiedAccessToken.Claims["seq"])
 	assert.Equal(t, role, verifiedAccessToken.Claims["role"])
 	assert.Equal(t, deviceID, verifiedAccessToken.Claims["deviceUniqueID"])
-	assert.Equal(t, "claimData", verifiedAccessToken.Claims["reallyCustomClaim"])
 	_, err = client.VerifyToken(ctx, refreshToken)
 	require.Error(t, err, ErrWrongTypeToken)
 }
@@ -210,9 +208,8 @@ func TestParseToken_Parse(t *testing.T) { //nolint:funlen // .
 		email    = "bogus@bogus.com"
 		role     = "author"
 		deviceID = "00000000-0000-0000-0000-000000000001"
-		claims   = map[string]any{"role": role}
 	)
-	refreshToken, accessToken, err := client.GenerateTokens(now, userID, deviceID, email, hashCode, seq, claims)
+	refreshToken, accessToken, err := client.GenerateTokens(now, userID, deviceID, email, hashCode, seq, role)
 	require.NoError(t, err)
 	assert.NotEmpty(t, refreshToken)
 	assert.NotEmpty(t, accessToken)
@@ -267,20 +264,17 @@ func TestMetadata_Empty(t *testing.T) {
 	assert.Equal(t, userID, decodedMetadata["sub"])
 	assert.Equal(t, internal.MetadataIssuer, decodedMetadata["iss"])
 	assert.Equal(t, now.Unix(), int64(decodedMetadata["iat"].(float64))) //nolint:forcetypeassert // .
-
 	tok := &Token{UserID: userID}
-	err = client.ModifyTokenWithMetadata(tok, metadataToken)
+	tok, err = client.ModifyTokenWithMetadata(tok, metadataToken)
 	require.NoError(t, err)
 	assert.Equal(t, userID, tok.UserID)
-
 	err = client.(*auth).ice.VerifyTokenFields(metadataToken, &decodedMetadata) //nolint:forcetypeassert // .
 	require.NoError(t, err)
 	assert.Equal(t, 3, len(decodedMetadata))
 	assert.Equal(t, userID, decodedMetadata["sub"])
 	assert.Equal(t, internal.MetadataIssuer, decodedMetadata["iss"])
 	assert.Equal(t, now.Unix(), int64(decodedMetadata["iat"].(float64))) //nolint:forcetypeassert // .
-
-	err = client.ModifyTokenWithMetadata(tok, "")
+	tok, err = client.ModifyTokenWithMetadata(tok, "")
 	require.NoError(t, err)
 	assert.Equal(t, tok.UserID, userID)
 }
@@ -313,7 +307,7 @@ func TestMetadata_RegisteredBy(t *testing.T) { //nolint:funlen // .
 		assert.Equal(t, provider, decodedMetadata[RegisteredWithProviderClaim])
 
 		tok := &Token{UserID: userID}
-		err = client.ModifyTokenWithMetadata(tok, metadataToken)
+		tok, err = client.ModifyTokenWithMetadata(tok, metadataToken)
 		require.NoError(t, err)
 		assert.Equal(t, tok.UserID, result)
 
@@ -357,6 +351,6 @@ func TestMetadata_MetadataNotOwnedByToken(t *testing.T) {
 	assert.NotEmpty(t, metadataToken)
 
 	tok := &Token{UserID: uuid.NewString()} // Metadata was issued for token "userID", not random one.
-	err = client.ModifyTokenWithMetadata(tok, metadataToken)
+	_, err = client.ModifyTokenWithMetadata(tok, metadataToken)
 	require.Error(t, err, ErrInvalidToken)
 }

--- a/auth/contract.go
+++ b/auth/contract.go
@@ -38,9 +38,9 @@ type (
 		ParseToken(token string) (*IceToken, error)
 		UpdateCustomClaims(ctx context.Context, userID string, customClaims map[string]any) error
 		DeleteUser(ctx context.Context, userID string) error
-		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
+		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (string, string, error)
 		GenerateMetadata(now *time.Time, userID string, md map[string]any) (string, error)
-		ModifyTokenWithMetadata(token *Token, metadataStr string) error
+		ModifyTokenWithMetadata(token *Token, metadataStr string) (*Token, error)
 	}
 )
 

--- a/auth/contract.go
+++ b/auth/contract.go
@@ -39,6 +39,7 @@ type (
 		UpdateCustomClaims(ctx context.Context, userID string, customClaims map[string]any) error
 		DeleteUser(ctx context.Context, userID string) error
 		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
+		GenerateMetadata(now *time.Time, userID string, md map[string]any) (string, error)
 	}
 )
 

--- a/auth/contract.go
+++ b/auth/contract.go
@@ -14,8 +14,8 @@ import (
 // Public API.
 
 const (
-	IceIDClaim                  = firebaseauth.IceIDClaim
-	FirebaseIDClaim             = iceauth.FirebaseIDClaim
+	IceIDClaim                  = internal.IceIDClaim
+	FirebaseIDClaim             = internal.FirebaseIDClaim
 	ProviderIce                 = internal.ProviderIce
 	ProviderFirebase            = internal.ProviderFirebase
 	RegisteredWithProviderClaim = internal.RegisteredWithProviderClaim
@@ -40,6 +40,7 @@ type (
 		DeleteUser(ctx context.Context, userID string) error
 		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
 		GenerateMetadata(now *time.Time, userID string, md map[string]any) (string, error)
+		ModifyTokenWithMetadata(token *Token, metadataStr string) error
 	}
 )
 

--- a/auth/contract.go
+++ b/auth/contract.go
@@ -38,6 +38,7 @@ type (
 		ParseToken(token string) (*IceToken, error)
 		UpdateCustomClaims(ctx context.Context, userID string, customClaims map[string]any) error
 		DeleteUser(ctx context.Context, userID string) error
+		UpdateEmail(ctx context.Context, userID, email string) error
 		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (string, string, error)
 		GenerateMetadata(now *time.Time, userID string, md map[string]any) (string, error)
 		ModifyTokenWithMetadata(token *Token, metadataStr string) (*Token, error)

--- a/auth/contract.go
+++ b/auth/contract.go
@@ -39,7 +39,7 @@ type (
 		UpdateCustomClaims(ctx context.Context, userID string, customClaims map[string]any) error
 		DeleteUser(ctx context.Context, userID string) error
 		UpdateEmail(ctx context.Context, userID, email string) error
-		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (string, string, error)
+		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (accessToken, refreshToken string, err error)
 		GenerateMetadata(now *time.Time, userID string, md map[string]any) (string, error)
 		ModifyTokenWithMetadata(token *Token, metadataStr string) (*Token, error)
 	}

--- a/auth/fixture/fixture.go
+++ b/auth/fixture/fixture.go
@@ -99,9 +99,8 @@ func GenerateIceTokens(userID, role string) (refreshToken, accessToken string, e
 		deviceUniqueID = uuid.NewString()
 		seq            = int64(0)
 		hashCode       = int64(0)
-		claims         = map[string]any{"role": role}
 	)
-	refreshToken, accessToken, err = clientIce().GenerateTokens(now, userID, deviceUniqueID, email, hashCode, seq, claims)
+	refreshToken, accessToken, err = clientIce().GenerateTokens(now, userID, deviceUniqueID, email, hashCode, seq, role)
 
 	return
 }

--- a/auth/internal/contract.go
+++ b/auth/internal/contract.go
@@ -7,9 +7,12 @@ package internal
 const (
 	RefreshJwtIssuer            = "ice.io/refresh"
 	AccessJwtIssuer             = "ice.io/access"
+	MetadataIssuer              = "ice.io/metadata"
 	RegisteredWithProviderClaim = "registeredWithProvider"
 	ProviderFirebase            = "firebase"
 	ProviderIce                 = "ice"
+	FirebaseIDClaim             = "firebaseId"
+	IceIDClaim                  = "iceId"
 )
 
 type (

--- a/auth/internal/firebase/auth.go
+++ b/auth/internal/firebase/auth.go
@@ -57,20 +57,12 @@ func (a *auth) VerifyToken(ctx context.Context, token string) (*internal.Token, 
 	}
 	var email, role string
 	userID := firebaseToken.UID
-	if len(firebaseToken.Claims) > 0 { //nolint:nestif // .
+	if len(firebaseToken.Claims) > 0 {
 		if emailInterface, found := firebaseToken.Claims["email"]; found {
 			email, _ = emailInterface.(string) //nolint:errcheck // Not needed.
 		}
 		if roleInterface, found := firebaseToken.Claims["role"]; found {
 			role, _ = roleInterface.(string) //nolint:errcheck // Not needed.
-		}
-		if registeredWithProviderInterface, found := firebaseToken.Claims[internal.RegisteredWithProviderClaim]; found {
-			registeredWithProvider := registeredWithProviderInterface.(string) //nolint:errcheck,forcetypeassert // Not needed.
-			if registeredWithProvider == internal.ProviderIce {
-				if iceIDInterface, ok := firebaseToken.Claims[IceIDClaim]; ok {
-					userID, _ = iceIDInterface.(string) //nolint:errcheck // Not needed.
-				}
-			}
 		}
 	}
 

--- a/auth/internal/firebase/auth.go
+++ b/auth/internal/firebase/auth.go
@@ -101,6 +101,24 @@ func (a *auth) UpdateCustomClaims(ctx context.Context, userID string, customClai
 	return nil
 }
 
+func (a *auth) UpdateEmail(ctx context.Context, userID, email string) error {
+	if ctx.Err() != nil {
+		return errors.Wrap(ctx.Err(), "context failed")
+	}
+	if _, err := a.client.UpdateUser(ctx, userID, new(firebaseAuth.UserToUpdate).Email(email).EmailVerified(true)); err != nil {
+		if strings.HasSuffix(err.Error(), "user with the provided email already exists") {
+			return ErrConflict
+		}
+		if strings.HasSuffix(err.Error(), "no user record found for the given identifier") {
+			return ErrUserNotFound
+		}
+
+		return errors.Wrapf(err, "failed to update email to `%v`, for userID:`%v`", email, userID)
+	}
+
+	return nil
+}
+
 func (a *auth) DeleteUser(ctx context.Context, userID string) error {
 	if ctx.Err() != nil {
 		return errors.Wrap(ctx.Err(), "context failed")

--- a/auth/internal/firebase/contract.go
+++ b/auth/internal/firebase/contract.go
@@ -23,6 +23,7 @@ type (
 		VerifyToken(ctx context.Context, token string) (*internal.Token, error)
 		UpdateCustomClaims(ctx context.Context, userID string, customClaims map[string]any) error
 		DeleteUser(ctx context.Context, userID string) error
+		UpdateEmail(ctx context.Context, userID, email string) error
 		GetUser(ctx context.Context, userID string) (*firebaseAuth.UserRecord, error)
 	}
 )

--- a/auth/internal/firebase/contract.go
+++ b/auth/internal/firebase/contract.go
@@ -13,10 +13,6 @@ import (
 
 // Public API.
 
-const (
-	IceIDClaim = "iceId"
-)
-
 var (
 	ErrUserNotFound = errors.New("user not found")
 	ErrConflict     = errors.New("change conflicts with another user")

--- a/auth/internal/ice/auth.go
+++ b/auth/internal/ice/auth.go
@@ -31,7 +31,7 @@ func (a *auth) VerifyToken(token string) (*internal.Token, error) {
 	var iceToken Token
 	err := a.VerifyTokenFields(token, &iceToken)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invalid email token:%v", token)
+		return nil, errors.Wrapf(err, "invalid token")
 	}
 	if iceToken.Issuer != internal.AccessJwtIssuer {
 		return nil, errors.Wrapf(ErrWrongTypeToken, "access to endpoint with refresh token: %v", iceToken.Issuer)
@@ -51,11 +51,6 @@ func (a *auth) VerifyToken(token string) (*internal.Token, error) {
 		Role:     iceToken.Role,
 		Provider: internal.ProviderIce,
 	}
-	if iceToken.Custom != nil {
-		for claimKey, claimValue := range *iceToken.Custom {
-			tok.Claims[claimKey] = claimValue
-		}
-	}
 
 	return tok, nil
 }
@@ -63,7 +58,7 @@ func (a *auth) VerifyToken(token string) (*internal.Token, error) {
 func (a *auth) VerifyTokenFields(jwtToken string, res jwt.Claims) error {
 	if _, err := jwt.ParseWithClaims(jwtToken, res, a.verify()); err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) || errors.Is(err, jwt.ErrTokenNotValidYet) {
-			return errors.Wrapf(ErrExpiredToken, "expired or not valid yet token:%v", jwtToken)
+			return errors.Wrapf(ErrExpiredToken, "expired or not valid yet token")
 		}
 
 		return errors.Wrapf(err, "invalid token:%v", jwtToken)

--- a/auth/internal/ice/contract.go
+++ b/auth/internal/ice/contract.go
@@ -23,19 +23,18 @@ var (
 type (
 	Client interface {
 		VerifyToken(token string) (*internal.Token, error)
-		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
+		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (string, string, error)
 		VerifyTokenFields(token string, res jwt.Claims) error
 		GenerateMetadata(now *time.Time, tokenID string, metadata map[string]any) (string, error)
 	}
 
 	Token struct {
 		*jwt.RegisteredClaims
-		Custom         *map[string]any `json:"custom,omitempty"`
-		Role           string          `json:"role" example:"1"`
-		Email          string          `json:"email" example:"jdoe@example.com"`
-		DeviceUniqueID string          `json:"deviceUniqueId" example:"6FB988F3-36F4-433D-9C7C-555887E57EB2"`
-		HashCode       int64           `json:"hashCode,omitempty" example:"12356789"`
-		Seq            int64           `json:"seq" example:"1"`
+		Role           string `json:"role" example:"1"`
+		Email          string `json:"email" example:"jdoe@example.com"`
+		DeviceUniqueID string `json:"deviceUniqueId" example:"6FB988F3-36F4-433D-9C7C-555887E57EB2"`
+		HashCode       int64  `json:"hashCode,omitempty" example:"12356789"`
+		Seq            int64  `json:"seq" example:"1"`
 	}
 )
 

--- a/auth/internal/ice/contract.go
+++ b/auth/internal/ice/contract.go
@@ -25,7 +25,6 @@ type (
 		VerifyToken(token string) (*internal.Token, error)
 		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
 		VerifyTokenFields(token string, res jwt.Claims) error
-
 		GenerateMetadata(now *time.Time, tokenID string, metadata map[string]any) (string, error)
 	}
 

--- a/auth/internal/ice/contract.go
+++ b/auth/internal/ice/contract.go
@@ -23,7 +23,7 @@ var (
 type (
 	Client interface {
 		VerifyToken(token string) (*internal.Token, error)
-		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (string, string, error)
+		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, role string) (accessToken, refreshToken string, err error)
 		VerifyTokenFields(token string, res jwt.Claims) error
 		GenerateMetadata(now *time.Time, tokenID string, metadata map[string]any) (string, error)
 	}

--- a/auth/internal/ice/contract.go
+++ b/auth/internal/ice/contract.go
@@ -14,10 +14,6 @@ import (
 
 // Public API.
 
-const (
-	FirebaseIDClaim = "firebaseId"
-)
-
 var (
 	ErrInvalidToken   = errors.New("invalid token")
 	ErrExpiredToken   = errors.New("expired token")
@@ -30,7 +26,7 @@ type (
 		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
 		VerifyTokenFields(token string, res jwt.Claims) error
 
-		GenerateMetadata(now *time.Time, userID string, metadata map[string]any) (string, error)
+		GenerateMetadata(now *time.Time, tokenID string, metadata map[string]any) (string, error)
 	}
 
 	Token struct {
@@ -45,9 +41,6 @@ type (
 )
 
 // Private API.
-const (
-	metadataIssuer = "ice.io/metadata"
-)
 
 type (
 	auth struct {

--- a/auth/internal/ice/contract.go
+++ b/auth/internal/ice/contract.go
@@ -29,6 +29,8 @@ type (
 		VerifyToken(token string) (*internal.Token, error)
 		GenerateTokens(now *time.Time, userID, deviceUniqueID, email string, hashCode, seq int64, claims map[string]any) (string, string, error)
 		VerifyTokenFields(token string, res jwt.Claims) error
+
+		GenerateMetadata(now *time.Time, userID string, metadata map[string]any) (string, error)
 	}
 
 	Token struct {
@@ -43,6 +45,9 @@ type (
 )
 
 // Private API.
+const (
+	metadataIssuer = "ice.io/metadata"
+)
 
 type (
 	auth struct {

--- a/auth/internal/ice/tokens_generate.go
+++ b/auth/internal/ice/tokens_generate.go
@@ -81,3 +81,13 @@ func (a *auth) generateAccessToken(
 
 	return tokenStr, errors.Wrapf(err, "failed to generate access token for userID:%v, email:%v, deviceUniqueId:%v", userID, email, deviceUniqueID)
 }
+
+func (a *auth) GenerateMetadata(now *time.Time, userID string, metadata map[string]any) (string, error) {
+	metadata["sub"] = userID
+	metadata["iss"] = metadataIssuer
+	metadata["iat"] = jwt.NewNumericDate(*now.Time)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(metadata))
+	tokenStr, err := a.signToken(token)
+
+	return tokenStr, errors.Wrapf(err, "failed to generate metadata token for payload userID:%v, metadata:%#v", userID, metadata)
+}

--- a/auth/internal/ice/tokens_generate.go
+++ b/auth/internal/ice/tokens_generate.go
@@ -16,13 +16,13 @@ func (a *auth) GenerateTokens(
 	userID, deviceUniqueID, email string,
 	hashCode,
 	seq int64,
-	claims map[string]any,
+	role string,
 ) (refreshToken, accessToken string, err error) {
 	refreshToken, err = a.generateRefreshToken(now, userID, deviceUniqueID, email, seq)
 	if err != nil {
 		return "", "", errors.Wrapf(err, "failed to generate jwt refreshToken for userID:%v", userID)
 	}
-	accessToken, err = a.generateAccessToken(now, seq, hashCode, userID, deviceUniqueID, email, claims)
+	accessToken, err = a.generateAccessToken(now, seq, hashCode, userID, deviceUniqueID, email, role)
 
 	return refreshToken, accessToken, errors.Wrapf(err, "failed to generate jwt accessToken for userID:%v", userID)
 }
@@ -45,23 +45,12 @@ func (a *auth) generateRefreshToken(now *time.Time, userID, deviceUniqueID, emai
 	return refreshToken, errors.Wrapf(err, "failed to generate refresh token for userID:%v, email:%v, deviceUniqueId:%v", userID, email, deviceUniqueID)
 }
 
-//nolint:funlen,revive // Fields.
+//nolint:revive // Fields.
 func (a *auth) generateAccessToken(
 	now *time.Time, refreshTokenSeq, hashCode int64,
 	userID, deviceUniqueID, email string,
-	claims map[string]any,
+	role string,
 ) (string, error) {
-	var customClaims *map[string]any
-	role := ""
-	if clRole, ok := claims["role"]; ok {
-		if roleS, isStr := clRole.(string); isStr {
-			role = roleS
-			delete(claims, "role")
-		}
-	}
-	if len(claims) > 0 {
-		customClaims = &claims
-	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, Token{
 		RegisteredClaims: &jwt.RegisteredClaims{
 			Issuer:    internal.AccessJwtIssuer,
@@ -75,7 +64,6 @@ func (a *auth) generateAccessToken(
 		DeviceUniqueID: deviceUniqueID,
 		HashCode:       hashCode,
 		Seq:            refreshTokenSeq,
-		Custom:         customClaims,
 	})
 	tokenStr, err := a.signToken(token)
 

--- a/auth/internal/ice/tokens_generate.go
+++ b/auth/internal/ice/tokens_generate.go
@@ -82,12 +82,12 @@ func (a *auth) generateAccessToken(
 	return tokenStr, errors.Wrapf(err, "failed to generate access token for userID:%v, email:%v, deviceUniqueId:%v", userID, email, deviceUniqueID)
 }
 
-func (a *auth) GenerateMetadata(now *time.Time, userID string, metadata map[string]any) (string, error) {
-	metadata["sub"] = userID
-	metadata["iss"] = metadataIssuer
+func (a *auth) GenerateMetadata(now *time.Time, tokenID string, metadata map[string]any) (string, error) {
+	metadata["sub"] = tokenID
+	metadata["iss"] = internal.MetadataIssuer
 	metadata["iat"] = jwt.NewNumericDate(*now.Time)
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(metadata))
 	tokenStr, err := a.signToken(token)
 
-	return tokenStr, errors.Wrapf(err, "failed to generate metadata token for payload userID:%v, metadata:%#v", userID, metadata)
+	return tokenStr, errors.Wrapf(err, "failed to generate metadata token for payload tokenID:%v, metadata:%#v", tokenID, metadata)
 }

--- a/server/router.go
+++ b/server/router.go
@@ -179,7 +179,7 @@ func (req *Request[REQ, RESP]) authorize(ctx context.Context) (errResp *Response
 		return Unauthorized(err)
 	}
 	metadataHeader := req.ginCtx.GetHeader("X-Account-Metadata")
-	if err = Auth(ctx).ModifyTokenWithMetadata(token, metadataHeader); err != nil {
+	if token, err = Auth(ctx).ModifyTokenWithMetadata(token, metadataHeader); err != nil {
 		return Unauthorized(err)
 	}
 	req.AuthenticatedUser.Token = *token


### PR DESCRIPTION
Adds helper functions to generate signed user's metadata payload, and verification step.
Adds support of X-Account-Metadata header to provide metadata for requests to bridging accounts between ice tokens and firebase tokens (VerifyToken uses only native token's ID and then in is updated by metadata information, so `req.AuthenticatedUser.UserID` leads to the provider user first registered).
Functions to update user's email in firebase restored.